### PR TITLE
Create languages find none found for updating greetings

### DIFF
--- a/src/main/java/com/keyin/hello/GreetingService.java
+++ b/src/main/java/com/keyin/hello/GreetingService.java
@@ -2,7 +2,6 @@ package com.keyin.hello;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
 
 import java.util.*;
 
@@ -38,13 +37,7 @@ public class GreetingService {
 
             newGreeting.setLanguages(languageArrayList);
         } else {
-            for (Language language : newGreeting.getLanguages()) {
-                Language langInDB = languageRepository.findByName(language.getName());
-
-                if (langInDB == null) {
-                    language = languageRepository.save(language);
-                }
-            }
+            newGreeting.setLanguages(findOrCreateLanguages(newGreeting.getLanguages()));
         }
 
         return greetingRepository.save(newGreeting);
@@ -59,7 +52,7 @@ public class GreetingService {
 
         greetingToUpdate.setName(updatedGreeting.getName());
         greetingToUpdate.setGreeting(updatedGreeting.getGreeting());
-        greetingToUpdate.setLanguages(findOrCreateLanguage(updatedGreeting.getLanguages()));
+        greetingToUpdate.setLanguages(findOrCreateLanguages(updatedGreeting.getLanguages()));
 
         return greetingRepository.save(greetingToUpdate);
     }
@@ -76,7 +69,7 @@ public class GreetingService {
      * Takes a list of languages and finds the corresponding database language or
      * creates a new one if not found.
      */
-    private List<Language> findOrCreateLanguage(List<Language> languages) {
+    private List<Language> findOrCreateLanguages(List<Language> languages) {
         List<Language> newLanguages = new ArrayList<>();
         for (Language language : languages) {
             String name = language.getName();

--- a/src/main/java/com/keyin/hello/GreetingService.java
+++ b/src/main/java/com/keyin/hello/GreetingService.java
@@ -59,7 +59,7 @@ public class GreetingService {
 
         greetingToUpdate.setName(updatedGreeting.getName());
         greetingToUpdate.setGreeting(updatedGreeting.getGreeting());
-        greetingToUpdate.setLanguages(updatedGreeting.getLanguages());
+        greetingToUpdate.setLanguages(findOrCreateLanguage(updatedGreeting.getLanguages()));
 
         return greetingRepository.save(greetingToUpdate);
     }
@@ -70,5 +70,22 @@ public class GreetingService {
 
     public List<Greeting> findGreetingsByNameAndGreeting(String name, String greetingName) {
         return greetingRepository.findByNameAndGreeting(name, greetingName);
+    }
+
+    /**
+     * Takes a list of languages and finds the corresponding database language or
+     * creates a new one if not found.
+     */
+    private List<Language> findOrCreateLanguage(List<Language> languages) {
+        List<Language> newLanguages = new ArrayList<>();
+        for (Language language : languages) {
+            String name = language.getName();
+            language = languageRepository.findByName(name);
+            if (language == null) {
+                language = languageRepository.save(new Language(name));
+            }
+            newLanguages.add(language);
+        }
+        return newLanguages;
     }
 }

--- a/src/main/java/com/keyin/hello/Language.java
+++ b/src/main/java/com/keyin/hello/Language.java
@@ -15,7 +15,11 @@ public class Language {
     private String name;
 
     public Language() {
-        this.name = "English";
+        this("English");
+    }
+
+    public Language(String name) {
+        this.name = name;
     }
 
     public long getId() {


### PR DESCRIPTION
### Changes
- Changes that the update endpoint for greetings (PUT /greeting/{index}) never created languages when a new language was encountered like the create endpoint (POST /greeting)
- Added new constructor for Language to allow for its name to be passed in and updated its default usage of no parameter constructor to use this in case of any side effects that may be added to the constructor in the future.
- For the above operation of fixing the update endpoint a new method `findOrCreateLanguages` was created, this method will go trough a list of languages and find the said language in the database or create a new one, the previous create method that did this same operation has been changed to use this new method.