### PR TITLE
Bug Fixing, Add languages through Put

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ build/
 
 ### Mac OS ###
 .DS_Store
+src/main/resources/application.properties

--- a/src/main/java/com/keyin/hello/GreetingService.java
+++ b/src/main/java/com/keyin/hello/GreetingService.java
@@ -25,6 +25,8 @@ public class GreetingService {
     }
 
     public Greeting createGreeting(Greeting newGreeting) {
+        newGreeting.setId(0);
+
         if (newGreeting.getLanguages() == null) {
             Language english = languageRepository.findByName("English");
 
@@ -38,13 +40,21 @@ public class GreetingService {
 
             newGreeting.setLanguages(languageArrayList);
         } else {
+            ArrayList<Language> languageArrayList = new ArrayList<Language>();
             for (Language language : newGreeting.getLanguages()) {
                 Language langInDB = languageRepository.findByName(language.getName());
 
                 if (langInDB == null) {
                     language = languageRepository.save(language);
+                    languageArrayList.add(language);
+                } else {
+                    language.setId(0);
+                    language = langInDB;
+                    languageArrayList.add(language);
                 }
+
             }
+            newGreeting.setLanguages(languageArrayList);
         }
 
         return greetingRepository.save(newGreeting);
@@ -59,7 +69,22 @@ public class GreetingService {
 
         greetingToUpdate.setName(updatedGreeting.getName());
         greetingToUpdate.setGreeting(updatedGreeting.getGreeting());
-        greetingToUpdate.setLanguages(updatedGreeting.getLanguages());
+
+        ArrayList<Language> languageArrayList = new ArrayList<Language>();
+        for (Language language : updatedGreeting.getLanguages()) {
+            Language langInDB = languageRepository.findByName(language.getName());
+
+            if (langInDB == null) {
+                language.setId(0);
+                language = languageRepository.save(language);
+                languageArrayList.add(language);
+            } else {
+                language = langInDB;
+                languageArrayList.add(language);
+            }
+        }
+
+        greetingToUpdate.setLanguages(languageArrayList);
 
         return greetingRepository.save(greetingToUpdate);
     }


### PR DESCRIPTION
Did some tweaks to create so that it will only create new greetings instead using the entered object's id and overriding an existing one. 
Same logic applied to languages, and now getting the ID of a language wrong will no longer fail the api call. I do this by using the "findByName" repo command to ensure that the language uses the correct ID if it exists.
Finally, one can create new languages via the put command if they do not exist in the database. This is also done using the "findByName" repo command.